### PR TITLE
Fixes #39. JObject Pseudo Type Conversion

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,11 @@
+## v2.3.1-beta-2
+* BREAKING: Issue 39 - Pseudo types are now converted by default in JToken types (JObject, JArray).
+*   You'll need to specify .Run*(conn, new { time_format: `raw` }) to keep raw types
+*   from being converted. Other raw types: binary_format and group_format.
+
 ## v2.3.1-beta-1
 * Compatibility with RethinkDB 2.3 and new user/pass authentication system.
-* New 'Grant' AST term added.
+* New `Grant` AST term added.
 * New permission exception types.
 * Issue 41 - Synchronous Run Helpers now throw expected exceptions (unwrapped AggregateException).
 

--- a/Source/RethinkDb.Driver.Tests/App.config
+++ b/Source/RethinkDb.Driver.Tests/App.config
@@ -6,8 +6,8 @@
     </sectionGroup>
   </configSections>
     <appSettings>
-        <!--<add key="TestServer" value="127.0.0.1"/>-->
-        <add key="TestServer" value="192.168.0.140"/>
+        <add key="TestServer" value="127.0.0.1"/>
+        <!--<add key="TestServer" value="192.168.0.140"/>-->
         
         <add key="TestPort" value="28015"/>
     </appSettings>

--- a/Source/RethinkDb.Driver.Tests/ReQL/GitHubIssues.cs
+++ b/Source/RethinkDb.Driver.Tests/ReQL/GitHubIssues.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using RethinkDb.Driver.Model;
 using RethinkDb.Driver.Tests.Utils;
 
+
 namespace RethinkDb.Driver.Tests.ReQL
 {
     public class Basket
@@ -86,85 +87,7 @@ namespace RethinkDb.Driver.Tests.ReQL
         }
 
 
-        public class TheJObject
-        {
-            public string TheString { get; set; }
-            public float TheFloat { get; set; }
-            public double TheDouble { get; set; }
-            public decimal TheDecimal { get; set; }
-            public byte[] TheBinary { get; set; }
-            public bool TheBoolean { get; set; }
-            public DateTime TheDateTime { get; set; }
-            public DateTimeOffset TheDateTimeOffset { get; set; }
-            public Guid TheGuid { get; set; }
-            public TimeSpan TheTimeSpan { get; set; }
-            public int TheInt { get; set; }
-            public long TheLong { get; set; }
-        }
-        [Test]
-        public void issue_21_allow_JObject_inserts()
-        {
-            var table = R.Db(DbName).Table(TableName);
-            table.Delete().Run(conn);
-
-            var state = new JObject
-                {
-                    ["TheString"] = "issue 21",
-                    ["TheFloat"] = 25.2f,
-                    ["TheDouble"] = 25.3d,
-                    ["TheDecimal"] = 25.4m,
-                    ["TheBinary"] = new byte[] {0, 2, 3, 255},
-                    ["TheBoolean"] = true,
-                    ["TheDateTime"] = new DateTime(2011, 11, 1, 11, 11, 11, DateTimeKind.Local),
-                    ["TheDateTimeOffset"] = new DateTimeOffset(2011, 11, 1, 11, 11, 11, 11, TimeSpan.FromHours(-8)).ToUniversalTime(),
-                    ["TheGuid"] = Guid.Empty,
-                    ["TheTimeSpan"] = TimeSpan.FromHours(3),
-                    ["TheInt"] = 25,
-                    ["TheLong"] = 82342342234,
-                    ["NestedObject"] = new JObject
-                        {
-                            ["NestedString"] = "StringValue",
-                            ["NestedDate"] = new DateTime(2011, 11, 1, 11, 11, 11, DateTimeKind.Local)
-                        },
-                    ["NestedArray"] = new JArray
-                        {
-                            {
-                                new JObject
-                                    {
-                                        ["SongName"] = "Song 1",
-                                        ["SongLength"] = "4:14"
-                                    }
-                            },
-                            new JObject
-                                    {
-                                        ["SongName"] = "Song 2",
-                                        ["SongLength"] = "3:10"
-                                    }
-                        }
-                };
-            
-            Console.WriteLine(">>> INSERT");
-            var result = table.Insert(state).RunResult(conn);
-            var id = result.GeneratedKeys[0];
-            result.Dump();
-
-            var check = table.Get(id).RunAtom<TheJObject>(conn);
-            check.Dump();
-
-            check.TheString.Should().Be((string)state["TheString"]);
-            check.TheFloat.Should().Be((float)state["TheFloat"]);
-            check.TheDouble.Should().Be((double)state["TheDouble"]);
-            check.TheDecimal.Should().Be((decimal)state["TheDecimal"]);
-            check.TheBinary.Should().BeEquivalentTo((byte[])state["TheBinary"]);
-            check.TheBoolean.Should().Be((bool)state["TheBoolean"]);
-            check.TheDateTime.Should().Be((DateTime)state["TheDateTime"]);
-            check.TheDateTimeOffset.Should().Be((DateTimeOffset)state["TheDateTimeOffset"]);
-            check.TheGuid.Should().Be((Guid)state["TheGuid"]);
-            check.TheTimeSpan.Should().Be((TimeSpan)state["TheTimeSpan"]);
-            check.TheInt.Should().Be((int)state["TheInt"]);
-            check.TheLong.Should().Be((long)state["TheLong"]);
-        }
-
+     
 
         [Test]
         public void issue_21_raw_json_test()
@@ -231,29 +154,6 @@ namespace RethinkDb.Driver.Tests.ReQL
                     }
                 });
         }
-
-        [Test]
-        public void issue_39()
-        {
-            var dateTime = DateTime.Parse("2016-09-03T10:30:20Z");
-            var obj = new JObject(new JProperty("timestamp", dateTime));
-
-            var table = R.Db(DbName).Table(TableName);
-            table.Delete().Run(conn);
-
-            var result = table.Insert(obj).RunResult(conn);
-            var id = result.GeneratedKeys[0];
-
-            var check = table.Get(id).RunAtom<JObject>(conn);
-            check.Dump();
-
-            var dtProper = check["timestamp"].ToObject<DateTime>(Net.Converter.Serializer);
-            dtProper.Should().Be(dateTime);
-
-            //var dt = (DateTime)check["timestamp"];
-            //dt.Should().Be(dateTime);
-        }
-
 
         [Test]
         public void issue_41_ensure_run_helpers_throw_error_first_before_direct_conversion()

--- a/Source/RethinkDb.Driver.Tests/ReQL/JObjectTests.cs
+++ b/Source/RethinkDb.Driver.Tests/ReQL/JObjectTests.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using RethinkDb.Driver.Net;
+using RethinkDb.Driver.Tests.Utils;
+
+namespace RethinkDb.Driver.Tests.ReQL
+{
+    [TestFixture]
+    public class JObjectTests : QueryTestFixture
+    {
+        public class TheJObject
+        {
+            public string TheString { get; set; }
+            public float TheFloat { get; set; }
+            public double TheDouble { get; set; }
+            public decimal TheDecimal { get; set; }
+            public byte[] TheBinary { get; set; }
+            public bool TheBoolean { get; set; }
+            public DateTime TheDateTime { get; set; }
+            public DateTimeOffset TheDateTimeOffset { get; set; }
+            public Guid TheGuid { get; set; }
+            public TimeSpan TheTimeSpan { get; set; }
+            public int TheInt { get; set; }
+            public long TheLong { get; set; }
+        }
+
+        [SetUp]
+        public void BeforeEachTest()
+        {
+            Converter.InitializeDefault();
+        }
+
+
+        [Test]
+        public void issue_21_allow_JObject_inserts()
+        {
+            var table = R.Db(DbName).Table(TableName);
+            table.Delete().Run(conn);
+
+            var state = new JObject
+            {
+                ["TheString"] = "issue 21",
+                ["TheFloat"] = 25.2f,
+                ["TheDouble"] = 25.3d,
+                ["TheDecimal"] = 25.4m,
+                ["TheBinary"] = new byte[] { 0, 2, 3, 255 },
+                ["TheBoolean"] = true,
+                ["TheDateTime"] = new DateTime(2011, 11, 1, 11, 11, 11, DateTimeKind.Local),
+                ["TheDateTimeOffset"] = new DateTimeOffset(2011, 11, 1, 11, 11, 11, 11, TimeSpan.FromHours(-8)).ToUniversalTime(),
+                ["TheGuid"] = Guid.Empty,
+                ["TheTimeSpan"] = TimeSpan.FromHours(3),
+                ["TheInt"] = 25,
+                ["TheLong"] = 82342342234,
+                ["NestedObject"] = new JObject
+                {
+                    ["NestedString"] = "StringValue",
+                    ["NestedDate"] = new DateTime(2011, 11, 1, 11, 11, 11, DateTimeKind.Local)
+                },
+                ["NestedArray"] = new JArray
+                        {
+                            {
+                                new JObject
+                                    {
+                                        ["SongName"] = "Song 1",
+                                        ["SongLength"] = "4:14"
+                                    }
+                            },
+                            new JObject
+                                    {
+                                        ["SongName"] = "Song 2",
+                                        ["SongLength"] = "3:10"
+                                    }
+                        }
+            };
+
+            Console.WriteLine(">>> INSERT");
+            var result = table.Insert(state).RunResult(conn);
+            var id = result.GeneratedKeys[0];
+            result.Dump();
+
+            var check = table.Get(id).RunAtom<TheJObject>(conn);
+            check.Dump();
+
+            check.TheString.Should().Be((string)state["TheString"]);
+            check.TheFloat.Should().Be((float)state["TheFloat"]);
+            check.TheDouble.Should().Be((double)state["TheDouble"]);
+            check.TheDecimal.Should().Be((decimal)state["TheDecimal"]);
+            check.TheBinary.Should().BeEquivalentTo((byte[])state["TheBinary"]);
+            check.TheBoolean.Should().Be((bool)state["TheBoolean"]);
+            check.TheDateTime.Should().Be((DateTime)state["TheDateTime"]);
+            check.TheDateTimeOffset.Should().Be((DateTimeOffset)state["TheDateTimeOffset"]);
+            check.TheGuid.Should().Be((Guid)state["TheGuid"]);
+            check.TheTimeSpan.Should().Be((TimeSpan)state["TheTimeSpan"]);
+            check.TheInt.Should().Be((int)state["TheInt"]);
+            check.TheLong.Should().Be((long)state["TheLong"]);
+        }
+
+        [Test]
+        public void issue_39()
+        {
+            var dateTime = DateTime.Parse("2016-09-03T10:30:20Z");
+            var obj = new JObject(new JProperty("timestamp", dateTime));
+
+            var table = R.Db(DbName).Table(TableName);
+            table.Delete().Run(conn);
+
+            var result = table.Insert(obj).RunResult(conn);
+            var id = result.GeneratedKeys[0];
+
+            var check = table.Get(id).RunAtom<JObject>(conn);
+            check.Dump();
+
+            var dt = (DateTime)check["timestamp"];
+            dt.Should().Be(dateTime);
+        }
+
+        [Test]
+        public void ensure_we_get_datetime_offset()
+        {
+            var json = @"{
+                            ""name"":""hello kitty"",
+                            ""dob"":""2016-09-03T10:30:20Z""
+                          }";
+
+            var settings = new JsonSerializerSettings
+                {
+                    DateParseHandling = DateParseHandling.DateTimeOffset
+                };
+
+            var fromJson = JsonConvert.DeserializeObject<JObject>(json, settings);
+
+            var fromDb = R.Expr(fromJson).RunResult<JObject>(conn);
+            var dateTimeValue = fromDb["dob"] as JValue;
+            dateTimeValue.Type.Should().Be(JTokenType.Date);
+
+            dateTimeValue.Value.Should().BeOfType<DateTime>();
+
+            Converter.Serializer.DateParseHandling = DateParseHandling.DateTimeOffset;
+
+            fromDb = R.Expr(fromJson).RunResult<JObject>(conn);
+
+            var dateTimeOffsetValue = fromDb["dob"] as JValue;
+            dateTimeOffsetValue.Type.Should().Be(JTokenType.Date);
+            dateTimeOffsetValue.Value.Should().BeOfType<DateTimeOffset>();
+        }
+
+        [Test]
+        public void should_not_see_any_pseudo_type_when_ser_deser_jtoken_by_default()
+        {
+            var vals = R.Expr(new
+            {
+                keya = R.Now(),
+                keyb = "foo"
+            }).values().RunResult<JArray>(conn);
+
+            var raw = vals.ToString();
+            raw.Dump();
+            raw.Should().Contain("foo");
+            raw.Should().NotContain(Converter.PseudoTypeKey);
+        }
+
+        [Test]
+        public void should_be_able_to_get_raw_values_if_we_want_them()
+        {
+            var vals = R.Expr(new
+            {
+                keya = R.Now(),
+                keyb = "foo"
+            }).values().RunResult<JArray>(conn, new {time_format = "raw"});
+
+            var raw = vals.ToString();
+            raw.Dump();
+            raw.Should().Contain("foo");
+            raw.Should().Contain(Converter.PseudoTypeKey);
+        }
+        
+    }
+
+}

--- a/Source/RethinkDb.Driver.Tests/ReQL/PocoTests.cs
+++ b/Source/RethinkDb.Driver.Tests/ReQL/PocoTests.cs
@@ -101,23 +101,6 @@ namespace RethinkDb.Driver.Tests.ReQL
 
             obj.Should().BeEquivalentTo("keya", "keyb");
         }
-
-        [Test]
-        public void can_ser_deser_reql_expr_anon_type()
-        {
-            
-            var vals = R.Expr(new
-            {
-                keya = R.Now(),
-                keyb = "foo"
-            }).values().RunResult<JArray>(conn);
-
-            var raw = vals.ToString();
-            raw.Dump();
-            raw.Should().Contain("foo");
-            raw.Should().Contain(Converter.PseudoTypeKey);
-        }
-
         
         [Test]
         public void can_bracket_on_table()

--- a/Source/RethinkDb.Driver.Tests/RethinkDb.Driver.Tests.csproj
+++ b/Source/RethinkDb.Driver.Tests/RethinkDb.Driver.Tests.csproj
@@ -122,6 +122,7 @@
     <Compile Include="ReQL\GitHubIssues.cs" />
     <Compile Include="ReQL\GitterIssues.cs" />
     <Compile Include="ReQL\GroupingTests.cs" />
+    <Compile Include="ReQL\JObjectTests.cs" />
     <Compile Include="ReQL\MapTests.cs" />
     <Compile Include="ReQL\OtherTests.cs" />
     <Compile Include="ReQL\PocoTests.cs" />

--- a/Source/RethinkDb.Driver/Net/Connection.cs
+++ b/Source/RethinkDb.Driver/Net/Connection.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -274,7 +275,13 @@ namespace RethinkDb.Driver.Net
             {
                 try
                 {
+                    if( typeof(T).IsJToken() )
+                    {
+                        var fmt = FormatOptions.FromOptArgs(query.GlobalOptions);
+                        return (T)Converter.ConvertPseudoTypes(res.Data[0], fmt);
+                    }
                     return res.Data[0].ToObject<T>(Converter.Serializer);
+                    
                 }
                 catch( IndexOutOfRangeException ex )
                 {
@@ -300,15 +307,25 @@ namespace RethinkDb.Driver.Net
             {
                 try
                 {
+                    if( typeof(T).IsJToken() )
+                    {
+                        var fmt = FormatOptions.FromOptArgs(query.GlobalOptions);
+                        return (T)Converter.ConvertPseudoTypes(res.Data[0], fmt);
+                    }
                     return res.Data[0].ToObject<T>(Converter.Serializer);
                 }
-                catch( IndexOutOfRangeException ex )
+                catch ( IndexOutOfRangeException ex )
                 {
                     throw new ReqlDriverError("Atom response was empty!", ex);
                 }
             }
             if( res.IsSequence )
             {
+                if( typeof(T).IsJToken() )
+                {
+                    var fmt = FormatOptions.FromOptArgs(query.GlobalOptions);
+                    return (T)Converter.ConvertPseudoTypes(res.Data, fmt);
+                }
                 return res.Data.ToObject<T>(Converter.Serializer);
             }
             if (res.IsError)
@@ -361,16 +378,20 @@ namespace RethinkDb.Driver.Net
             {
                 try
                 {
+                    if( typeof(T).IsJToken() )
+                    {
+                        var fmt = FormatOptions.FromOptArgs(query.GlobalOptions);
+                        return Converter.ConvertPseudoTypes(res.Data[0], fmt);
+                    }
                     return res.Data[0].ToObject(typeof(T), Converter.Serializer);
                 }
-                catch( IndexOutOfRangeException ex )
+                catch ( IndexOutOfRangeException ex )
                 {
                     throw new ReqlDriverError("Atom response was empty!", ex);
                 }
             }
             else if( res.IsPartial || res.IsSequence )
             {
-                //ICursor cursor = Cursor<T>.create(this, query, res);
                 return new Cursor<T>(this, query, res);
             }
             else if( res.IsWaitComplete )

--- a/Source/RethinkDb.Driver/Net/FormatOptions.cs
+++ b/Source/RethinkDb.Driver/Net/FormatOptions.cs
@@ -1,0 +1,52 @@
+using RethinkDb.Driver.Ast;
+using RethinkDb.Driver.Model;
+
+namespace RethinkDb.Driver.Net
+{
+    /// <summary>
+    /// ReQL pseudo type format options for JToken (JObject, JArray) derivatives.
+    /// </summary>
+    public class FormatOptions
+    {
+        /// <summary>
+        /// Leave $reql_time$:TIME types as raw
+        /// </summary>
+        public bool RawTime { get; set; }
+        /// <summary>
+        /// Leave $reql_time$:GROUPED_DATA types as raw
+        /// </summary>
+        public bool RawGroups { get; set; }
+
+        /// <summary>
+        /// Leave $reql_time$:BINARY types as raw
+        /// </summary>
+        public bool RawBinary { get; set; }
+
+        /// <summary>
+        /// Format options for JToken
+        /// </summary>
+        public FormatOptions()
+        {    
+        }
+
+        /// <summary>
+        /// Factory method for FormatOptions from OptArgs
+        /// </summary>
+        public static FormatOptions FromOptArgs(OptArgs args)
+        {
+            var fmt = new FormatOptions();
+            // TODO: find a better way to do this.
+            ReqlAst datum;
+            var value = args.TryGetValue("time_format", out datum) ? ((Datum)datum).datum : new Datum("native").datum;
+            fmt.RawTime = value.Equals("raw");
+
+            value = args.TryGetValue("binary_format", out datum) ? ((Datum)datum).datum : new Datum("native").datum;
+            fmt.RawBinary = value.Equals("raw");
+
+            value = args.TryGetValue("group_format", out datum) ? ((Datum)datum).datum : new Datum("native").datum;
+            fmt.RawGroups = value.Equals("raw");
+
+            return fmt;
+        }
+    }
+}

--- a/Source/RethinkDb.Driver/RethinkDb.Driver.csproj
+++ b/Source/RethinkDb.Driver/RethinkDb.Driver.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Net\Clustering\RoundRobinHostPool.cs" />
     <Compile Include="Net\Clustering\Server.cs" />
     <Compile Include="Net\Crypto.cs" />
+    <Compile Include="Net\FormatOptions.cs" />
     <Compile Include="Net\Handshake.cs" />
     <Compile Include="Net\IConnection.cs" />
     <Compile Include="Net\ICursor.cs" />

--- a/Source/RethinkDb.Driver/Utils/ExtensionsForType.cs
+++ b/Source/RethinkDb.Driver/Utils/ExtensionsForType.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using Newtonsoft.Json.Linq;
 
 namespace RethinkDb.Driver.Utils
 {
@@ -8,6 +9,10 @@ namespace RethinkDb.Driver.Utils
         public static bool IsASubclassOf(this Type type, Type other)
         {
             return type.GetTypeInfo().IsSubclassOf(other);
+        }
+        public static bool IsJToken(this Type type)
+        {
+            return type.IsASubclassOf(typeof(JToken));
         }
 
         public static bool IsGenericType(this Type type)


### PR DESCRIPTION
Fixes #39. Breaking Change: JObject and JArray (JToken derivatives) now, by default, get passed through pseudo type conversion before being passed back to the user.