### PR TITLE
Fixes #86 - `RunGrouping` where `Group("Field").Count()` reductions are values

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 ## v2.3.12
 * Issue #87 - Fixed missing `.User(user,pass)` parameters on `ConnectionPool` builder.
 * Fixed some synchronous methods not unwrapping `AggregateException`.
+* Issue #86 - Fixes `RunGrouping` where `Group("Field").Count()` reductions are values.
 
 ## v2.3.11
 * Added `ConnectionPool.AnyOpen` to check if any node is available in the host pool.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A [**RethinkDB**](http://rethinkdb.com/) database driver written in C# with 100%
 This driver is based on the *official* [Java Driver](https://github.com/rethinkdb/rethinkdb/tree/next/drivers/java). The basic mechanics and architecture of both drivers are the same. Except this **C#** driver is a bit more *cool*, *stylish* and *kick-ass*. :sunglasses:
 
 ###### Standout Features
-* 1,000+ Unit Tests - Passes the same ***ReQL*** test battery as the [official drivers](http://rethinkdb.com/docs/install-drivers/).
+* 1,200+ Unit Tests - This driver passes the same ***ReQL*** test harness as the [official drivers](http://rethinkdb.com/docs/install-drivers/).
 * [Awesome documentation](https://github.com/bchavez/RethinkDb.Driver/wiki).
 * [ReGrid Support](https://github.com/bchavez/RethinkDb.Driver/wiki/ReGrid-File-Storage) - Distributed Large Binary Storage
 

--- a/Source/RethinkDb.Driver.Tests/ReQL/GitHubIssues.cs
+++ b/Source/RethinkDb.Driver.Tests/ReQL/GitHubIssues.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Newtonsoft.Json;
@@ -228,6 +229,27 @@ namespace RethinkDb.Driver.Tests.ReQL
             typeof(JObject).IsJToken().Should().Be(true);
             typeof(JArray).IsJToken().Should().Be(true);
             typeof(JValue).IsJToken().Should().Be(true);
+        }
+
+
+        [Test]
+        public void issue_86_grouping_count_transforms_reduction()
+        {
+            var games = new[]
+                {
+                    new Game {id = 2, player = "Bob", points = 15, type = "ranked"},
+                    new Game {id = 5, player = "Alice", points = 7, type = "free"},
+                    new Game {id = 12, player = "Alice", points = 2, type = "free"},
+                };
+
+            var result = R.Expr(games)
+                .Group("player")
+                .Count()
+                .RunGrouping<string, int>(conn);
+
+            var groupings = result.ToArray();
+            groupings[0].Items[0].Should().Be(2);
+            groupings[1].Items[0].Should().Be(1);
         }
     }
 

--- a/Source/RethinkDb.Driver/Model/GroupedResult.cs
+++ b/Source/RethinkDb.Driver/Model/GroupedResult.cs
@@ -20,6 +20,12 @@ namespace RethinkDb.Driver.Model
             this.Key = key.ToObject<TKey>(Converter.Serializer);
             this.Items = items.ToObject<List<TElement>>(Converter.Serializer);
         }
+        public GroupedResult(JToken key, JValue item)
+        {
+            this.Key = key.ToObject<TKey>(Converter.Serializer);
+            var value = item.ToObject<TElement>(Converter.Serializer);
+            this.Items = new List<TElement>() {value};
+        }
 
         public IEnumerator<TElement> GetEnumerator()
         {


### PR DESCRIPTION
* Issue #86 - Fixes `RunGrouping` where `Group("Field").Count()` reductions are values.

Follows Java driver behavior.

:headphones: :notes: [***Antiserum & Mayhem - Trippy***](https://www.youtube.com/watch?v=o95ZTp5fuF8)