### PR TITLE
Use C# 7.1 features.

### DIFF
--- a/Source/RethinkDb.Driver.ReGrid/BaseStream.cs
+++ b/Source/RethinkDb.Driver.ReGrid/BaseStream.cs
@@ -26,6 +26,6 @@ namespace RethinkDb.Driver.ReGrid
         /// <summary>
         /// Async closure of the stream.
         /// </summary>
-        public abstract Task CloseAsync(CancellationToken cancelToken = default(CancellationToken));
+        public abstract Task CloseAsync(CancellationToken cancelToken = default);
     }
 }

--- a/Source/RethinkDb.Driver.ReGrid/Bucket.Download.cs
+++ b/Source/RethinkDb.Driver.ReGrid/Bucket.Download.cs
@@ -29,7 +29,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <param name="options"><see cref="DownloadOptions"/></param>
         /// <param name="cancelToken"><see cref="CancellationToken"/></param>
         public async Task<byte[]> DownloadAsBytesByNameAsync(string filename, int revision = -1, DownloadOptions options = null,
-            CancellationToken cancelToken = default(CancellationToken))
+            CancellationToken cancelToken = default)
         {
             options = options ?? new DownloadOptions();
             var fileInfo = await this.GetFileInfoByNameAsync(filename, revision, cancelToken)
@@ -44,7 +44,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <param name="filename">The file name</param>
         /// <param name="revision">-1: The most recent revision. -2: The second most recent revision. -3: The third most recent revision. 0: The original stored file. 1: The first revision. 2: The second revision. etc...</param>
         /// <param name="cancelToken"><see cref="CancellationToken"/></param>
-        public Task<byte[]> DownloadAsBytesByNameAsync(string filename, CancellationToken cancelToken, int revision = -1)
+        public Task<byte[]> DownloadAsBytesByNameAsync(string filename, CancellationToken cancelToken = default, int revision = -1)
         {
             return DownloadAsBytesByNameAsync(filename, revision, null, cancelToken);
         }
@@ -66,7 +66,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <param name="fileId">The fileId</param>
         /// <param name="options"><see cref="DownloadOptions"/></param>
         /// <param name="cancelToken"><see cref="CancellationToken"/></param>
-        public async Task<byte[]> DownloadAsBytesAsync(Guid fileId, DownloadOptions options = null, CancellationToken cancelToken = default(CancellationToken))
+        public async Task<byte[]> DownloadAsBytesAsync(Guid fileId, DownloadOptions options = null, CancellationToken cancelToken = default)
         {
             options = options ?? new DownloadOptions();
             return await DownloadBytesHelperAsync(fileId, options, cancelToken)
@@ -78,7 +78,7 @@ namespace RethinkDb.Driver.ReGrid
         /// </summary>
         /// <param name="fileId">The fileId</param>
         /// <param name="cancelToken"><see cref="CancellationToken"/></param>
-        public Task<byte[]> DownloadAsBytesAsync(Guid fileId, CancellationToken cancelToken)
+        public Task<byte[]> DownloadAsBytesAsync(Guid fileId, CancellationToken cancelToken = default)
         {
             return DownloadAsBytesAsync(fileId, null, cancelToken);
         }
@@ -104,7 +104,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <param name="options"><see cref="DownloadOptions"/></param>
         /// <param name="cancelToken"><see cref="CancellationToken"/></param>
         public async Task DownloadToStreamAsync(Guid fileId, Stream destination, DownloadOptions options = null,
-            CancellationToken cancelToken = default(CancellationToken))
+            CancellationToken cancelToken = default)
         {
             options = options ?? new DownloadOptions();
             await DownloadToStreamHelperAsync(fileId, destination, options, cancelToken)
@@ -117,7 +117,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <param name="fileId">The fileId</param>
         /// <param name="destination"></param>
         /// <param name="cancelToken"><see cref="CancellationToken"/></param>
-        public Task DownloadToStreamAsync(Guid fileId, Stream destination, CancellationToken cancelToken)
+        public Task DownloadToStreamAsync(Guid fileId, Stream destination, CancellationToken cancelToken = default)
         {
             return DownloadToStreamAsync(fileId, destination, null, cancelToken);
         }
@@ -144,7 +144,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <param name="options"><see cref="DownloadOptions"/></param>
         /// <param name="cancelToken"><see cref="CancellationToken"/></param>
         public async Task DownloadToStreamByNameAsync(string filename, Stream destination, int revision = -1, DownloadOptions options = null,
-            CancellationToken cancelToken = default(CancellationToken))
+            CancellationToken cancelToken = default)
         {
             Ensure.IsNotNull(filename, nameof(filename));
             Ensure.IsNotNull(destination, nameof(destination));
@@ -163,7 +163,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <param name="revision">-1: The most recent revision. -2: The second most recent revision. -3: The third most recent revision. 0: The original stored file. 1: The first revision. 2: The second revision. etc...</param>
         /// <param name="destination">The destination stream to write to.</param>
         /// <param name="cancelToken"><see cref="CancellationToken"/></param>
-        public Task DownloadToStreamByNameAsync(string filename, Stream destination, CancellationToken cancelToken, int revision = -1)
+        public Task DownloadToStreamByNameAsync(string filename, Stream destination, CancellationToken cancelToken = default, int revision = -1)
         {
             return DownloadToStreamByNameAsync(filename, destination, revision, null, cancelToken);
         }
@@ -189,7 +189,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <param name="options"><see cref="DownloadOptions"/></param>
         /// <param name="cancelToken"><see cref="CancellationToken"/></param>
         public async Task<DownloadStream> OpenDownloadStreamAsync(string filename, DownloadOptions options = null, int revision = -1,
-            CancellationToken cancelToken = default(CancellationToken))
+            CancellationToken cancelToken = default)
         {
             options = options ?? new DownloadOptions();
 
@@ -205,7 +205,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <param name="filename">The file name</param>
         /// <param name="revision">-1: The most recent revision. -2: The second most recent revision. -3: The third most recent revision. 0: The original stored file. 1: The first revision. 2: The second revision. etc...</param>
         /// <param name="cancelToken"><see cref="CancellationToken"/></param>
-        public Task<DownloadStream> OpenDownloadStreamAsync(string filename, CancellationToken cancelToken, int revision = -1)
+        public Task<DownloadStream> OpenDownloadStreamAsync(string filename, CancellationToken cancelToken = default, int revision = -1)
         {
             return OpenDownloadStreamAsync(filename, null, revision, cancelToken);
         }

--- a/Source/RethinkDb.Driver.ReGrid/Bucket.Purge.cs
+++ b/Source/RethinkDb.Driver.ReGrid/Bucket.Purge.cs
@@ -17,7 +17,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <summary>
         /// Erases all files from the system inside the bucket.
         /// </summary>
-        public async Task DestroyAsync(CancellationToken cancelToken = default(CancellationToken))
+        public async Task DestroyAsync(CancellationToken cancelToken = default)
         {
             try
             {

--- a/Source/RethinkDb.Driver.ReGrid/Bucket.Upload.cs
+++ b/Source/RethinkDb.Driver.ReGrid/Bucket.Upload.cs
@@ -17,7 +17,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <param name="source">Source bytes</param>
         /// <param name="options"><see cref="UploadOptions"/></param>
         /// <param name="cancelToken"><see cref="CancellationToken"/></param>
-        public async Task<Guid> UploadAsync(string filename, byte[] source, UploadOptions options = null, CancellationToken cancelToken = default(CancellationToken))
+        public async Task<Guid> UploadAsync(string filename, byte[] source, UploadOptions options = null, CancellationToken cancelToken = default)
         {
             using( var ms = new MemoryStream(source) )
             {
@@ -32,7 +32,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <param name="filename">The file name</param>
         /// <param name="source">Source bytes</param>
         /// <param name="cancelToken"><see cref="CancellationToken"/></param>
-        public Task<Guid> UploadAsync(string filename, byte[] source, CancellationToken cancelToken)
+        public Task<Guid> UploadAsync(string filename, byte[] source, CancellationToken cancelToken = default)
         {
             return UploadAsync(filename, source, null, cancelToken);
         }
@@ -44,7 +44,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <param name="source">Source stream</param>
         /// <param name="options"><see cref="UploadOptions"/></param>
         /// <param name="cancelToken"><see cref="CancellationToken"/></param>
-        public async Task<Guid> UploadAsync(string filename, Stream source, UploadOptions options = null, CancellationToken cancelToken = default(CancellationToken))
+        public async Task<Guid> UploadAsync(string filename, Stream source, UploadOptions options = null, CancellationToken cancelToken = default)
         {
             options = options ?? new UploadOptions();
             var uploadStream = await OpenUploadStreamAsync(filename, options, cancelToken).ConfigureAwait(false);
@@ -99,7 +99,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <param name="filename">The file name</param>
         /// <param name="source">Source stream</param>
         /// <param name="cancelToken"><see cref="CancellationToken"/></param>
-        public Task<Guid> UploadAsync(string filename, Stream source, CancellationToken cancelToken)
+        public Task<Guid> UploadAsync(string filename, Stream source, CancellationToken cancelToken = default)
         {
             return UploadAsync(filename, source, null, cancelToken);
         }
@@ -143,7 +143,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <param name="fileName">The file name</param>
         /// <param name="options"><see cref="UploadOptions"/></param>
         /// <param name="cancelToken"><see cref="CancellationToken"/></param>
-        public async Task<UploadStream> OpenUploadStreamAsync(string fileName, UploadOptions options = null, CancellationToken cancelToken = default(CancellationToken))
+        public async Task<UploadStream> OpenUploadStreamAsync(string fileName, UploadOptions options = null, CancellationToken cancelToken = default)
         {
             options = options ?? new UploadOptions();
 
@@ -156,7 +156,7 @@ namespace RethinkDb.Driver.ReGrid
         /// </summary>
         /// <param name="fileName">The file name</param>
         /// <param name="cancelToken"><see cref="CancellationToken"/></param>
-        public Task<UploadStream> OpenUploadStreamAsync(string fileName, CancellationToken cancelToken)
+        public Task<UploadStream> OpenUploadStreamAsync(string fileName, CancellationToken cancelToken = default )
         {
             return OpenUploadStreamAsync(fileName, null, cancelToken);
         }

--- a/Source/RethinkDb.Driver.ReGrid/Bucket.cs
+++ b/Source/RethinkDb.Driver.ReGrid/Bucket.cs
@@ -84,7 +84,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <summary>
         /// Mounts the bucket. Mount is necessary before using a bucket to ensure the existence of tables and indexes.
         /// </summary>
-        public async Task MountAsync(CancellationToken cancelToken = default(CancellationToken))
+        public async Task MountAsync(CancellationToken cancelToken = default)
         {
             if( this.Mounted )
                 return;
@@ -133,7 +133,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <summary>
         /// Helper function to create an index
         /// </summary>
-        protected internal async Task<JArray> CreateIndex(string tableName, string indexName, ReqlFunction1 indexFunc, CancellationToken cancelToken)
+        protected internal async Task<JArray> CreateIndex(string tableName, string indexName, ReqlFunction1 indexFunc, CancellationToken cancelToken = default)
         {
             await this.db.Table(tableName)
                 .IndexCreate(indexName, indexFunc).RunAtomAsync<JObject>(conn, cancelToken)
@@ -147,7 +147,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <summary>
         /// Helper function to ensure table exists.
         /// </summary>
-        protected internal async Task<Result> EnsureTable(string tableName, CancellationToken cancelToken)
+        protected internal async Task<Result> EnsureTable(string tableName, CancellationToken cancelToken = default)
         {
             return await this.db.TableList().Contains(tableName)
                 .Do_(tableExists =>

--- a/Source/RethinkDb.Driver.ReGrid/DownloadStreamBase.cs
+++ b/Source/RethinkDb.Driver.ReGrid/DownloadStreamBase.cs
@@ -25,7 +25,7 @@ namespace RethinkDb.Driver.ReGrid
         /// </summary>
         /// <param name="cancelToken"><see cref="CancellationToken"/></param>
         /// <returns></returns>
-        public override Task CloseAsync(CancellationToken cancelToken = default(CancellationToken))
+        public override Task CloseAsync(CancellationToken cancelToken = default)
         {
 #if !STANDARD
             base.Close();

--- a/Source/RethinkDb.Driver.ReGrid/DownloadStreamForwardOnly.cs
+++ b/Source/RethinkDb.Driver.ReGrid/DownloadStreamForwardOnly.cs
@@ -55,7 +55,7 @@ namespace RethinkDb.Driver.ReGrid
 #endif  
 
 
-        public override Task CloseAsync(CancellationToken cancelToken = default(CancellationToken))
+        public override Task CloseAsync(CancellationToken cancelToken = default)
         {
             CloseHelper();
             return base.CloseAsync(cancelToken);

--- a/Source/RethinkDb.Driver.ReGrid/FileSystemMethods.cs
+++ b/Source/RethinkDb.Driver.ReGrid/FileSystemMethods.cs
@@ -29,7 +29,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <summary>
         /// Gets all 'completed' file revisions for a given file. Deleted and incomplete files are excluded.
         /// </summary>
-        public static async Task<Cursor<FileInfo>> GetAllRevisionsAsync(this Bucket bucket, string filename, CancellationToken cancelToken = default(CancellationToken))
+        public static async Task<Cursor<FileInfo>> GetAllRevisionsAsync(this Bucket bucket, string filename, CancellationToken cancelToken = default)
         {
             filename = filename.SafePath();
 
@@ -55,7 +55,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <summary>
         /// Gets the FileInfo for a given fileId
         /// </summary>
-        public static async Task<FileInfo> GetFileInfoAsync(this Bucket bucket, Guid fileId, CancellationToken cancelToken = default(CancellationToken))
+        public static async Task<FileInfo> GetFileInfoAsync(this Bucket bucket, Guid fileId, CancellationToken cancelToken = default)
         {
             var fileInfo = await bucket.fileTable
                 .Get(fileId).RunAtomAsync<FileInfo>(bucket.conn, cancelToken)
@@ -88,7 +88,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <param name="cancelToken"><see cref="CancellationToken"/></param>
         /// <param name="filename">The filename</param>
         public static async Task<FileInfo> GetFileInfoByNameAsync(this Bucket bucket, string filename, int revision = -1,
-            CancellationToken cancelToken = default(CancellationToken))
+            CancellationToken cancelToken = default)
         {
             filename = filename.SafePath();
 
@@ -135,7 +135,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <param name="path">The path starting with /</param>
         /// <param name="bucket"><see cref="Bucket"/></param>
         /// <param name="cancelToken"><see cref="CancellationToken"/></param>
-        public static async Task<Cursor<FileInfo>> ListFilesByPrefixAsync(this Bucket bucket, string path, CancellationToken cancelToken = default(CancellationToken))
+        public static async Task<Cursor<FileInfo>> ListFilesByPrefixAsync(this Bucket bucket, string path, CancellationToken cancelToken = default)
         {
             path = path.SafePath();
 
@@ -178,7 +178,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <param name="cancelToken"><see cref="CancellationToken"/></param>
         /// <param name="fileId"><see cref="FileInfo.Id"/></param>
         public static async Task DeleteRevisionAsync(this Bucket bucket, Guid fileId, DeleteMode mode = DeleteMode.Soft, object deleteOpts = null,
-            CancellationToken cancelToken = default(CancellationToken))
+            CancellationToken cancelToken = default)
         {
             var result = await bucket.fileTable.Get(fileId)
                 .Update(

--- a/Source/RethinkDb.Driver.ReGrid/GridUtility.cs
+++ b/Source/RethinkDb.Driver.ReGrid/GridUtility.cs
@@ -32,7 +32,7 @@ namespace RethinkDb.Driver.ReGrid
         /// Enumerate the file system entries of a given particular status.
         /// </summary>
         public static async Task<Cursor<FileInfo>> EnumerateFileEntriesAsync(Bucket bucket, string filename, Status status,
-            CancellationToken cancelToken = default(CancellationToken))
+            CancellationToken cancelToken = default)
         {
             filename = filename.SafePath();
 
@@ -57,7 +57,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <summary>
         /// Enumerate all possible file system entries for a given filename
         /// </summary>
-        public static async Task<Cursor<FileInfo>> EnumerateFileEntriesAsync(Bucket bucket, string filename, CancellationToken cancelToken = default(CancellationToken))
+        public static async Task<Cursor<FileInfo>> EnumerateFileEntriesAsync(Bucket bucket, string filename, CancellationToken cancelToken = default)
         {
             filename = filename.SafePath();
 
@@ -82,7 +82,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <summary>
         /// Gets the enumeration of chunks for file id
         /// </summary>
-        public static async Task<Cursor<Chunk>> EnumerateChunksAsync(Bucket bucket, Guid fileId, CancellationToken cancelToken = default(CancellationToken))
+        public static async Task<Cursor<Chunk>> EnumerateChunksAsync(Bucket bucket, Guid fileId, CancellationToken cancelToken = default)
         {
             var index = new {index = bucket.chunkIndexName};
             return await bucket.chunkTable.Between(R.Array(fileId, R.Minval()), R.Array(fileId, R.Maxval()))[index]
@@ -102,7 +102,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <summary>
         /// Get a chunk in a bucket for file id.
         /// </summary>
-        public static async Task<Chunk> GetChunkAsync(Bucket bucket, Guid fileId, long n, CancellationToken cancelToken = default(CancellationToken))
+        public static async Task<Chunk> GetChunkAsync(Bucket bucket, Guid fileId, long n, CancellationToken cancelToken = default)
         {
             var index = new {index = bucket.chunkIndexName};
             return await bucket.chunkTable.GetAll(R.Array(fileId, n))[index]

--- a/Source/RethinkDb.Driver.ReGrid/RethinkDb.Driver.ReGrid.csproj
+++ b/Source/RethinkDb.Driver.ReGrid/RethinkDb.Driver.ReGrid.csproj
@@ -6,6 +6,7 @@
     <Version>0.0.0-localbuild</Version>
     <Authors>Brian Chavez</Authors>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>
     </AssemblyOriginatorKeyFile>

--- a/Source/RethinkDb.Driver.ReGrid/TimeSpanParser.cs
+++ b/Source/RethinkDb.Driver.ReGrid/TimeSpanParser.cs
@@ -80,7 +80,7 @@ namespace RethinkDb.Driver.ReGrid
                 }
             }
 
-            result = default(TimeSpan);
+            result = default;
             return false;
         }
     }

--- a/Source/RethinkDb.Driver.ReGrid/UploadStream.cs
+++ b/Source/RethinkDb.Driver.ReGrid/UploadStream.cs
@@ -82,7 +82,7 @@ namespace RethinkDb.Driver.ReGrid
         /// <summary>
         /// Async close the upload stream.
         /// </summary>
-        public override async Task CloseAsync(CancellationToken cancelToken = default(CancellationToken))
+        public override async Task CloseAsync(CancellationToken cancelToken = default)
         {
             await this.CloseInternalAsync(cancelToken).ConfigureAwait(false);
 #if !STANDARD
@@ -95,7 +95,7 @@ namespace RethinkDb.Driver.ReGrid
         /// </summary>
         /// <param name="cancelToken"></param>
         /// <returns></returns>
-        public async Task AbortAsync(CancellationToken cancelToken = default(CancellationToken))
+        public async Task AbortAsync(CancellationToken cancelToken = default)
         {
             if( aborted ) return;
 
@@ -186,7 +186,7 @@ namespace RethinkDb.Driver.ReGrid
             return chunks;
         }
 
-        private async Task CloseInternalAsync(CancellationToken cancelToken = default(CancellationToken))
+        private async Task CloseInternalAsync(CancellationToken cancelToken = default)
         {
             if (this.closed) return;
 

--- a/Source/RethinkDb.Driver/Ast/ReqlAst.cs
+++ b/Source/RethinkDb.Driver/Ast/ReqlAst.cs
@@ -66,7 +66,7 @@ namespace RethinkDb.Driver.Ast
         /// dynamic language runtime execution engine.
         /// </summary>
         /// <returns>Returns T or Cursor[T]</returns>
-        public virtual Task<dynamic> RunAsync<T>(IConnection conn, object runOpts = null, CancellationToken cancelToken = default(CancellationToken))
+        public virtual Task<dynamic> RunAsync<T>(IConnection conn, object runOpts = null, CancellationToken cancelToken = default)
         {
             return conn.RunAsync<T>(this, runOpts, cancelToken);
         }
@@ -96,7 +96,7 @@ namespace RethinkDb.Driver.Ast
         /// /// <param name="conn">connection</param>
         /// <param name="runOpts">global anonymous type optional arguments</param>
         /// <param name="cancelToken">Cancellation token used to stop *waiting* for a query response. The cancellation token does not cancel the query's execution on the server.</param>
-        public virtual Task<dynamic> RunAsync(IConnection conn, object runOpts = null, CancellationToken cancelToken = default(CancellationToken))
+        public virtual Task<dynamic> RunAsync(IConnection conn, object runOpts = null, CancellationToken cancelToken = default)
         {
             return RunAsync<dynamic>(conn, runOpts, cancelToken);
         }
@@ -165,7 +165,7 @@ namespace RethinkDb.Driver.Ast
         /// <param name="runOpts">global anonymous type optional arguments</param>
         /// <param name="cancelToken">Cancellation token used to stop *waiting* for a query response. The cancellation token does not cancel the query's execution on the server.</param>
         /// <returns>A Cursor</returns>
-        public virtual Task<Cursor<T>> RunCursorAsync<T>(IConnection conn, object runOpts = null, CancellationToken cancelToken = default(CancellationToken))
+        public virtual Task<Cursor<T>> RunCursorAsync<T>(IConnection conn, object runOpts = null, CancellationToken cancelToken = default)
         {
             return conn.RunCursorAsync<T>(this, runOpts, cancelToken);
         }
@@ -206,7 +206,7 @@ namespace RethinkDb.Driver.Ast
         /// <param name="conn">connection</param>
         /// <param name="runOpts">global anonymous type optional arguments</param>
         /// <param name="cancelToken">Cancellation token used to stop *waiting* for a query response. The cancellation token does not cancel the query's execution on the server.</param>
-        public virtual Task<T> RunAtomAsync<T>(IConnection conn, object runOpts = null, CancellationToken cancelToken = default(CancellationToken))
+        public virtual Task<T> RunAtomAsync<T>(IConnection conn, object runOpts = null, CancellationToken cancelToken = default)
         {
             return conn.RunAtomAsync<T>(this, runOpts, cancelToken);
         }
@@ -246,7 +246,7 @@ namespace RethinkDb.Driver.Ast
         /// <param name="conn">connection</param>
         /// <param name="runOpts">global anonymous type optional arguments</param>
         /// <param name="cancelToken">Cancellation token used to stop *waiting* for a query response. The cancellation token does not cancel the query's execution on the server.</param>
-        public virtual Task<T> RunResultAsync<T>(IConnection conn, object runOpts = null, CancellationToken cancelToken = default(CancellationToken))
+        public virtual Task<T> RunResultAsync<T>(IConnection conn, object runOpts = null, CancellationToken cancelToken = default)
         {
             return conn.RunResultAsync<T>(this, runOpts, cancelToken);
         }
@@ -292,7 +292,7 @@ namespace RethinkDb.Driver.Ast
         /// <param name="conn">connection</param>
         /// <param name="runOpts">global anonymous type optional arguments</param>
         /// <param name="cancelToken">Cancellation token used to stop *waiting* for a query response. The cancellation token does not cancel the query's execution on the server.</param>
-        public virtual Task<Result> RunResultAsync(IConnection conn, object runOpts = null, CancellationToken cancelToken = default(CancellationToken))
+        public virtual Task<Result> RunResultAsync(IConnection conn, object runOpts = null, CancellationToken cancelToken = default)
         {
             return conn.RunAtomAsync<Result>(this, runOpts, cancelToken);
         }
@@ -327,7 +327,7 @@ namespace RethinkDb.Driver.Ast
         /// <param name="conn">connection</param>
         /// <param name="runOpts">global anonymous type optional arguments</param>
         /// <param name="cancelToken">Cancellation token used to stop *waiting* for a query response. The cancellation token does not cancel the query's execution on the server.</param>
-        public virtual Task<Cursor<Change<T>>> RunChangesAsync<T>(IConnection conn, object runOpts = null, CancellationToken cancelToken = default(CancellationToken))
+        public virtual Task<Cursor<Change<T>>> RunChangesAsync<T>(IConnection conn, object runOpts = null, CancellationToken cancelToken = default)
         {
             return conn.RunCursorAsync<Change<T>>(this, runOpts, cancelToken);
         }
@@ -368,7 +368,7 @@ namespace RethinkDb.Driver.Ast
         /// <param name="runOpts">global anonymous type optional arguments</param>
         /// <param name="cancelToken">Cancellation token used to stop *waiting* for a query response. The cancellation token does not cancel the query's execution on the server.</param>
         public virtual async Task<IEnumerable<GroupedResult<TKey, TItem>>> RunGroupingAsync<TKey, TItem>(IConnection conn, object runOpts = null,
-            CancellationToken cancelToken = default(CancellationToken))
+            CancellationToken cancelToken = default)
         {
             var tsk = await RunAtomAsync<GroupedResultSet<TKey, TItem>>(conn, runOpts, cancelToken).ConfigureAwait(false);
             return tsk;

--- a/Source/RethinkDb.Driver/Net/Connection.cs
+++ b/Source/RethinkDb.Driver/Net/Connection.cs
@@ -218,7 +218,7 @@ namespace RethinkDb.Driver.Net
         /// been processed by the server. Note that this guarantee only apples to queries
         /// run on the same connection.
         /// </summary>
-        public virtual Task NoReplyWaitAsync(CancellationToken cancelToken = default(CancellationToken))
+        public virtual Task NoReplyWaitAsync(CancellationToken cancelToken = default)
         {
             return RunQueryWaitAsync(Query.NoReplyWait(NewToken()), cancelToken);
         }
@@ -227,7 +227,7 @@ namespace RethinkDb.Driver.Net
         /// <summary>
         /// Return the server name and server UUID being used by a connection.
         /// </summary>
-        public virtual async Task<Server> ServerAsync(CancellationToken cancelToken = default(CancellationToken))
+        public virtual async Task<Server> ServerAsync(CancellationToken cancelToken = default)
         {
             var response = await SendQuery(Query.ServerInfo(NewToken()), cancelToken, awaitResponse: true).ConfigureAwait(false);
             if( response.Type == ResponseType.SERVER_INFO )

--- a/Source/RethinkDb.Driver/Net/Cursor.cs
+++ b/Source/RethinkDb.Driver/Net/Cursor.cs
@@ -139,7 +139,7 @@ namespace RethinkDb.Driver.Net
         ///       will advance the cursor normally and maintain ordering of items.
         ///   </para>
         /// </exception>
-        public async Task<bool> MoveNextAsync(CancellationToken cancelToken = default(CancellationToken))
+        public async Task<bool> MoveNextAsync(CancellationToken cancelToken = default)
         {
             cancelToken.ThrowIfCancellationRequested();
             while( items.Count == 0 )

--- a/Source/RethinkDb.Driver/RethinkDb.Driver.csproj
+++ b/Source/RethinkDb.Driver/RethinkDb.Driver.csproj
@@ -6,6 +6,7 @@
     <Version>0.0.0-localbuild</Version>
     <Authors>Brian Chavez</Authors>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>
     </AssemblyOriginatorKeyFile>


### PR DESCRIPTION
Updates the RethinkDB database driver to use C# 7.1 compiler features. Cleans up `CancellationToken = default` nicely.

:fire: :volcano: ***["We're building it up, to break it back down..."](https://www.youtube.com/watch?v=dxytyRy-O1k)***