### PR TITLE
Fixes #125, use the configured NamingStrategy when translating linq queries.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+# v2.3.22
+* Issue #125 - Fixed LINQ provider not using Newtonsoft.Json naming strategy.
+
 # v2.3.21
 * ReGrid: Renamed bucket method `DestroyAsync` to `PergeAsync` to be consistent with non-async `Purge` call.
 

--- a/Source/RethinkDb.Driver.Linq.Tests/BaseLinqTest.cs
+++ b/Source/RethinkDb.Driver.Linq.Tests/BaseLinqTest.cs
@@ -13,6 +13,7 @@ using RethinkDb.Driver.Linq.Attributes;
 using RethinkDb.Driver.Net;
 using RethinkDb.Driver.Proto;
 using RethinkDb.Driver.Tests;
+using RethinkDb.Driver.Utils;
 
 namespace RethinkDb.Driver.Linq.Tests
 {
@@ -101,7 +102,7 @@ namespace RethinkDb.Driver.Linq.Tests
             var secondaryIndexes = typeof( T ).GetProperties().Where( x => x.CustomAttributes.Any( a => a.AttributeType == typeof( SecondaryIndexAttribute ) ) );
             foreach( var secondaryIndex in secondaryIndexes )
             {
-                RethinkDB.R.Table( TableName ).IndexCreate( secondaryIndex.Name ).Run( Connection );
+                RethinkDB.R.Table( TableName ).IndexCreate( QueryHelper.GetJsonMemberName( secondaryIndex ) ).Run( Connection );
             }
             RethinkDB.R.Table( TableName ).IndexWait().Run( Connection );
 

--- a/Source/RethinkDb.Driver.Linq.Tests/NamingStrategyTests.cs
+++ b/Source/RethinkDb.Driver.Linq.Tests/NamingStrategyTests.cs
@@ -1,0 +1,282 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Newtonsoft.Json.Serialization;
+using System;
+using RethinkDb.Driver.Linq.Attributes;
+using RethinkDb.Driver.Net;
+using Newtonsoft.Json;
+
+namespace RethinkDb.Driver.Linq.Tests
+{
+    [TestFixture]
+    public class NamingStrategyTests : BaseLinqTest
+    {
+        [DatapointSource]
+        public DefaultContractResolver[] ContractResolvers =
+        {
+            new DefaultContractResolver(),
+            new CamelCasePropertyNamesContractResolver(),
+            new DefaultContractResolver
+            {
+                NamingStrategy = new SnakeCaseNamingStrategy()
+            }
+        };
+
+        readonly List<TestObject> data = new List<TestObject>
+        {
+            new TestObject
+            {
+                SimpleProperty = "Property value 1",
+                IndexedProperty = "Indexed property value 1",
+                SimpleField = 1,
+            },
+            new TestObject
+            {
+                SimpleProperty = "Property value 2",
+                IndexedProperty = "Indexed property value 2",
+                SimpleField = 2,
+            }
+        };
+        
+        [Theory]
+        public void Where_RespectsConfiguredNamingStrategy(DefaultContractResolver contractResolver)
+        {
+            using (WithContractResolver(contractResolver))
+            {
+                SpawnData( data );
+                
+                var namingStrategy = contractResolver.NamingStrategy ?? new DefaultNamingStrategy();
+    
+                var expected = RethinkDB.R.Table( TableName )
+                    .Filter( x => x[namingStrategy.GetPropertyName( nameof(TestObject.SimpleProperty), false )].Eq( data[0].SimpleProperty ) )
+                    .Filter( x => x[namingStrategy.GetPropertyName( nameof(TestObject.SimpleField), false )].Gt( data[0].SimpleField ) );
+    
+                var queryable = GetQueryable<TestObject>( TableName, expected );
+           
+                var result =
+                (
+                    from testObject in queryable
+                    where testObject.SimpleProperty == data[0].SimpleProperty
+                    where testObject.SimpleField > data[0].SimpleField
+                    select testObject
+                ).ToList();
+
+                Assert.NotNull(result);
+            }
+        }
+        
+        [Theory]
+        public void WhereWithIndex_RespectsConfiguredNamingStrategy(DefaultContractResolver contractResolver)
+        {
+            using (WithContractResolver(contractResolver))
+            {
+                SpawnData( data );
+                
+                var namingStrategy = contractResolver.NamingStrategy ?? new DefaultNamingStrategy();
+    
+                var expected = RethinkDB.R.Table( TableName )
+                    .GetAll( data[0].IndexedProperty )
+                    .OptArg( "index", namingStrategy.GetPropertyName( nameof(TestObject.IndexedProperty), false ) );
+    
+                var queryable = GetQueryable<TestObject>( TableName, expected );
+            
+                var result =
+                (
+                    from testObject in queryable
+                    where testObject.IndexedProperty == data[0].IndexedProperty
+                    select testObject
+                ).ToList();
+
+                Assert.NotNull(result);
+            }
+        }
+        
+        [Theory]
+        public void Orderby_RespectsConfiguredNamingStrategy(DefaultContractResolver contractResolver)
+        {
+            using (WithContractResolver(contractResolver))
+            {
+                SpawnData( data );
+                
+                var namingStrategy = contractResolver.NamingStrategy ?? new DefaultNamingStrategy();
+    
+                var expected = RethinkDB.R.Table( TableName )
+                    .OrderBy( namingStrategy.GetPropertyName( nameof(TestObject.SimpleProperty), false ) );
+    
+                var queryable = GetQueryable<TestObject>( TableName, expected );
+            
+                var result =
+                (
+                    from testObject in queryable
+                    orderby testObject.SimpleProperty
+                    select testObject
+                ).ToList();
+
+                Assert.NotNull(result);
+            }
+        }
+        
+        [Theory]
+        public void OrderbyField_RespectsConfiguredNamingStrategy(DefaultContractResolver contractResolver)
+        {
+            using (WithContractResolver(contractResolver))
+            {
+                SpawnData( data );
+                
+                var namingStrategy = contractResolver.NamingStrategy ?? new DefaultNamingStrategy();
+    
+                var expected = RethinkDB.R.Table( TableName )
+                    .OrderBy( namingStrategy.GetPropertyName( nameof(TestObject.SimpleField), false ) );
+    
+                var queryable = GetQueryable<TestObject>( TableName, expected );
+            
+                var result =
+                (
+                    from testObject in queryable
+                    orderby testObject.SimpleField
+                    select testObject
+                ).ToList();
+
+                Assert.NotNull(result);
+            }
+        }
+        
+        [Theory]
+        public void OrderbyWithIndex_RespectsConfiguredNamingStrategy(DefaultContractResolver contractResolver)
+        {
+            using (WithContractResolver(contractResolver))
+            {
+                SpawnData( data );
+                
+                var namingStrategy = contractResolver.NamingStrategy ?? new DefaultNamingStrategy();
+    
+                var expected = RethinkDB.R.Table( TableName )
+                    .OrderBy( namingStrategy.GetPropertyName( nameof(TestObject.IndexedProperty), false ) )
+                    .OptArg( "index", namingStrategy.GetPropertyName( nameof(TestObject.IndexedProperty), false ) );
+    
+                var queryable = GetQueryable<TestObject>( TableName, expected );
+            
+                var result =
+                (
+                    from testObject in queryable
+                    orderby testObject.IndexedProperty
+                    select testObject
+                ).ToList();
+
+                Assert.NotNull(result);
+            }
+        }
+        
+        [Theory]
+        public void Groupby_RespectsConfiguredNamingStrategy(DefaultContractResolver contractResolver)
+        {
+            using (WithContractResolver(contractResolver))
+            {
+                SpawnData( data );
+                
+                var namingStrategy = contractResolver.NamingStrategy ?? new DefaultNamingStrategy();
+    
+                var expected = RethinkDB.R.Table( TableName )
+                    .Group(namingStrategy.GetPropertyName( nameof(TestObject.SimpleProperty), false ) )
+                    .Ungroup();
+    
+                var queryable = GetQueryable<TestObject>( TableName, expected );
+            
+                var result = queryable
+                    .GroupBy(testObject => testObject.SimpleProperty)
+                    .ToList();
+
+                Assert.NotNull(result);
+            }
+        }
+        
+        [Theory]
+        public void GroupbyField_RespectsConfiguredNamingStrategy(DefaultContractResolver contractResolver)
+        {
+            using (WithContractResolver(contractResolver))
+            {
+                SpawnData( data );
+                
+                var namingStrategy = contractResolver.NamingStrategy ?? new DefaultNamingStrategy();
+    
+                var expected = RethinkDB.R.Table( TableName )
+                    .Group(namingStrategy.GetPropertyName( nameof(TestObject.SimpleField), false ) )
+                    .Ungroup();
+    
+                var queryable = GetQueryable<TestObject>( TableName, expected );
+            
+                var result = queryable
+                    .GroupBy(testObject => testObject.SimpleField)
+                    .ToList();
+
+                Assert.NotNull(result);
+            }
+        }
+        
+        [Theory]
+        public void GroupbyWithSelector_RespectsConfiguredNamingStrategy(DefaultContractResolver contractResolver)
+        {
+            using (WithContractResolver(contractResolver))
+            {
+                SpawnData( data );
+                
+                var namingStrategy = contractResolver.NamingStrategy ?? new DefaultNamingStrategy();
+    
+                var expected = RethinkDB.R.Table( TableName )
+                    .Group( namingStrategy.GetPropertyName( nameof(TestObject.SimpleProperty), false ) )
+                    .GetField( namingStrategy.GetPropertyName( nameof(TestObject.SimpleField), false ) )
+                    .Ungroup();
+    
+                var queryable = GetQueryable<TestObject>( TableName, expected );
+            
+                var result = 
+                (
+                    from testObject in queryable
+                    group testObject.SimpleField by testObject.SimpleProperty into g
+                    select g
+                ).ToList();
+
+                Assert.NotNull(result);
+            }
+        }
+        
+        static IDisposable WithContractResolver(IContractResolver contractResolver)
+        {
+            var original = Converter.Serializer;
+            
+            Converter.Serializer = JsonSerializer.Create(new JsonSerializerSettings
+            {
+                Converters = Converter.Converters,
+                ContractResolver = contractResolver
+            });
+            
+            return new Disposable(() => Converter.Serializer = original); 
+        }
+
+        class TestObject
+        {
+            public string SimpleProperty { get; set; }
+            
+            [SecondaryIndex]
+            public string IndexedProperty { get; set; }
+
+            public int SimpleField;
+        }
+
+        class Disposable : IDisposable
+        {
+            readonly Action action;
+
+            public Disposable(Action action)
+            {
+                this.action = action;
+            }
+
+            public void Dispose()
+            {
+                action();
+            }
+        }
+    }
+}

--- a/Source/RethinkDb.Driver.Linq.Tests/RethinkDb.Driver.Linq.Tests.csproj
+++ b/Source/RethinkDb.Driver.Linq.Tests/RethinkDb.Driver.Linq.Tests.csproj
@@ -99,6 +99,7 @@
     <Compile Include="LastOrDefaultTests.cs" />
     <Compile Include="LastTests.cs" />
     <Compile Include="LinqExamples.cs" />
+    <Compile Include="NamingStrategyTests.cs" />
     <Compile Include="OrderByTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestRethinkQueryExecuter.cs" />

--- a/Source/RethinkDb.Driver.Linq/MemberNameResolver.cs
+++ b/Source/RethinkDb.Driver.Linq/MemberNameResolver.cs
@@ -5,6 +5,7 @@ using System.Linq.Expressions;
 using Remotion.Linq.Clauses.Expressions;
 using RethinkDb.Driver.Ast;
 using RethinkDb.Driver.Linq.WhereClauseParsers.SubQueryVisitor;
+using RethinkDb.Driver.Utils;
 
 namespace RethinkDb.Driver.Linq
 {
@@ -25,7 +26,7 @@ namespace RethinkDb.Driver.Linq
                 reqlExpr = ResolveMemberExpression( reqlExpr, (MemberExpression)expression.Expression );
             if( expression.Expression.NodeType == ExpressionType.Extension && expression.Expression is SubQueryExpression )
                 reqlExpr = ResolveExtensionExpression( reqlExpr, (SubQueryExpression)expression.Expression );
-            return reqlExpr[expression.Member.Name];
+            return reqlExpr[QueryHelper.GetJsonMemberName( expression.Member )];
         }
 
         private static ReqlExpr ResolveExtensionExpression( ReqlExpr reqlExpr, SubQueryExpression expression )

--- a/Source/RethinkDb.Driver.Linq/WhereClauseParsers/SecondaryIndexParser.cs
+++ b/Source/RethinkDb.Driver.Linq/WhereClauseParsers/SecondaryIndexParser.cs
@@ -2,6 +2,7 @@
 using Remotion.Linq;
 using RethinkDb.Driver.Ast;
 using RethinkDb.Driver.Linq.Attributes;
+using RethinkDb.Driver.Utils;
 
 namespace RethinkDb.Driver.Linq.WhereClauseParsers
 {
@@ -18,7 +19,8 @@ namespace RethinkDb.Driver.Linq.WhereClauseParsers
         private static string GetIndexName( BinaryExpression binaryExpression )
         {
             var left = binaryExpression.Left as MemberExpression;
-            return left?.Member.Name ?? ( (MemberExpression)binaryExpression.Right ).Member.Name;
+            var memberExpression = left ?? ( (MemberExpression)binaryExpression.Right );
+            return QueryHelper.GetJsonMemberName( memberExpression.Member );
         }
     }
 }

--- a/Source/RethinkDb.Driver/Utils/QueryHelper.cs
+++ b/Source/RethinkDb.Driver/Utils/QueryHelper.cs
@@ -1,0 +1,32 @@
+﻿using System.Reflection;
+using RethinkDb.Driver.Net;
+using Newtonsoft.Json.Serialization;
+
+namespace RethinkDb.Driver.Utils
+{
+    /// <summary>
+    /// Provides methods that assist in the translation of linq queries.
+    /// </summary>
+    public static class QueryHelper
+    {
+        /// <summary>
+        /// Gets the name of the database field that corresponds to the given class member.
+        /// The mapping can be configured by setting <see cref="Converter.Serializer"/> to a custom Serializer.
+        /// </summary>
+        public static string GetJsonMemberName(MemberInfo member)
+        {
+            if ( !(Converter.Serializer?.ContractResolver is DefaultContractResolver contractResolver) )
+            {
+                return member.Name;
+            }
+
+            var namingStrategy = contractResolver.NamingStrategy;
+            if ( namingStrategy == null )
+            {
+                return member.Name;
+            }
+
+            return namingStrategy.GetPropertyName( member.Name, false );
+        }
+    }
+}


### PR DESCRIPTION

- [x] I have signed the [**RethinkDB CLA**](http://rethinkdb.com/community/cla).

Issue: https://github.com/bchavez/RethinkDb.Driver/issues/125

There were some more places that used the property in the query besides the one mentioned in the issue so I updated those as well.
The tests don't cover every single operator but they do exercise all the code paths that contain my changes.

I followed your advice (thank you!) pretty closely, the only difference is the signature of `GetJsonMemberName` which takes a `MemberInfo` as an argument. 
I think this should make it easier to extend if necessary i.e. if it becomes necessary to read attributes from the property, however I can change that if you prefer.